### PR TITLE
fix humann2, templates, and kneaddata

### DIFF
--- a/cluster_template.yaml
+++ b/cluster_template.yaml
@@ -10,7 +10,7 @@ kneaddata:
 
 kneaddata_gzip:
     processors: 1
-    time: "00:30"
+    time: "0-01:00" # 1 hour
 
 metaphlan2:
     processors: 8
@@ -19,4 +19,4 @@ metaphlan2:
 humann2:
     processors: 8
     memory: 24000 # 24 Gb
-    time: "12:00" # 12 hours
+    time: "0-12:00" # 12 hours

--- a/config_template.yaml
+++ b/config_template.yaml
@@ -6,8 +6,8 @@
 # workflow variables
 #-------------------
 ---
-input_folder: ""
-output_folder: ""
+input_folder: "rawfastq"
+output_folder: "output"
 run: all
 
 #----------------------

--- a/workflows/humann2.snakefile
+++ b/workflows/humann2.snakefile
@@ -4,22 +4,26 @@
 
 rule humann2:
     input:
-        os.path.join(metaphlanfolder, "main", "{sample}.sam")
+        seq = os.path.join(kneadfolder, "{sample}_merged.fastq"),
+        tax = os.path.join(metaphlanfolder, "main", "{sample}_profile.tsv")
     output:
         samples = os.path.join(humannfolder, "main", "{sample}_genefamilies.tsv"),
         path = os.path.join(humannfolder, "main", "{sample}_pathabundance.tsv")
     run:
         # TODO: get threads from settings
-        shell("humann2 --input {{input}} --output {} --threads 8 --nucleotide-database {} --protein-database {} --input-format sam --remove-temp-output".format(
-            os.path.join(humannfolder, "main"),
-            config["databases"]["chocophlan"],
-            config["databases"]["uniref"]))
+        shell("humann2 --input {{input.seq}} --taxonomic-profile {{input.tax}} --output {} --threads 8 --remove-temp-output --search-mode uniref90 --output-basename {{wildcards.sample}}".format(
+            os.path.join(humannfolder, "main")))
 
 
 rule humann2_regroup_ecs:
     input: os.path.join(humannfolder, "main", "{sample}_genefamilies.tsv")
     output: os.path.join(humannfolder, "regroup", "{sample}_ecs.tsv")
-    run: shell("humann2_regroup_table --input {input} --output {output} --groups uniref90_rxn")
+    run: shell("humann2_regroup_table --input {input} --output {output} --groups uniref90_level4ec")
+
+rule humann2_regroup_kos:
+    input: os.path.join(humannfolder, "main", "{sample}_genefamilies.tsv")
+    output: os.path.join(humannfolder, "regroup", "{sample}_kos.tsv")
+    run: shell("humann2_regroup_table --input {input} --output {output} --groups uniref90_ko")
 
 rule humann2_renorm_gf:
     input: os.path.join(humannfolder, "main", "{sample}_genefamilies.tsv")
@@ -31,60 +35,42 @@ rule humann2_renorm_ecs:
     output: os.path.join(humannfolder, "relab", "{sample}_ecs_relab.tsv")
     run: shell("humann2_renorm_table -i {input} -o {output} -u relab")
 
+rule humann2_renorm_kos:
+    input: os.path.join(humannfolder, "regroup", "{sample}_kos.tsv")
+    output: os.path.join(humannfolder, "relab", "{sample}_kos_relab.tsv")
+    run: shell("humann2_renorm_table -i {input} -o {output} -u relab")
+
 rule humann2_renorm_paths:
     input: os.path.join(humannfolder, "main", "{sample}_pathabundance.tsv")
     output: os.path.join(humannfolder, "relab", "{sample}_pathabundance_relab.tsv")
     run: shell("humann2_renorm_table -i {input} -o {output} -u relab")
 
 
-# rule humann2_rename_gf:
-#     input: os.path.join(humannfolder, "main", "{samples}_genefamilies.tsv")
-#     output: os.path.join(humannfolder, "main", "{samples}_genefamilies_names.tsv"),
-#     run:
-#         shell("humann2_rename_table --input {input} --output {output} --names uniref90")
+rule humann2_rename_gf:
+    input: os.path.join(humannfolder, "relab", "{samples}_genefamilies_relab.tsv")
+    output: os.path.join(humannfolder, "main", "{samples}_genefamilies_names.tsv")
+    run:
+        shell("humann2_rename_table --input {input} --output {output} --names uniref90")
 
+rule humann2_rename_ecs:
+    input: os.path.join(humannfolder, "relab", "{samples}_ecs_relab.tsv")
+    output: os.path.join(humannfolder, "main", "{samples}_ecs_names.tsv")
+    run:
+        shell("humann2_rename_table --input {input} --output {output} --names uniref90")
 
-
-###############
-# All samples #
-###############
-
-rule humann2_merge_gf:
-    input: expand(os.path.join(humannfolder, "main", "{sample}_genefamilies.tsv"), sample = samples)
-    output: os.path.join(humannfolder, "merged", "genefamilies.tsv")
-    run: shell("humann2_join_tables -i {} -o {{output}} --file_name genefamilies".format(os.path.join(humannfolder, "main")))
-
-rule humann2_merge_ecs:
-    input: expand(os.path.join(humannfolder, "regroup", "{sample}_ecs.tsv"), sample = samples)
-    output: os.path.join(humannfolder, "merged", "ecs.tsv")
-    run: shell("humann2_join_tables -i {} -o {{output}} --file_name ecs".format(os.path.join(humannfolder, "regroup")))
-
-rule humann2_merge_paths:
-    input: expand(os.path.join(humannfolder, "main", "{sample}_pathabundance.tsv"), sample = samples)
-    output: os.path.join(humannfolder, "merged", "pathabundance.tsv")
-    run: shell("humann2_join_tables -i {} -o {{output}} --file_name pathabundance".format(os.path.join(humannfolder, "main")))
-
-rule humann2_merge_gf_relab:
-    input: expand(os.path.join(humannfolder, "relab", "{sample}_genefamilies_relab.tsv"), sample = samples)
-    output: os.path.join(humannfolder, "merged", "genefamilies_relab.tsv")
-    run: shell("humann2_join_tables -i {} -o {{output}} --file_name genefamilies_relab".format(os.path.join(humannfolder, "relab")))
-
-rule humann2_merge_ecs_relab:
-    input: expand(os.path.join(humannfolder, "relab", "{sample}_ecs_relab.tsv"), sample = samples)
-    output: os.path.join(humannfolder, "merged", "ecs_relab.tsv")
-    run: shell("humann2_join_tables -i {} -o {{output}} --file_name ecs_relab".format(os.path.join(humannfolder, "relab")))
-
-rule humann2_merge_paths_relab:
-    input: expand(os.path.join(humannfolder, "relab", "{sample}_pathabundance_relab.tsv"), sample = samples)
-    output: os.path.join(humannfolder, "merged", "pathabundance_relab.tsv")
-    run: shell("humann2_join_tables -i {} -o {{output}} --file_name pathabundance_relab".format(os.path.join(humannfolder, "relab")))
+rule humann2_rename_kos:
+    input: os.path.join(humannfolder, "relab", "{samples}_kos_relab.tsv")
+    output: os.path.join(humannfolder, "main", "{samples}_kos_names.tsv")
+    run:
+        shell("humann2_rename_table --input {input} --output {output} --names uniref90")
 
 
 rule humann2_report:
     input:
-        gf = os.path.join(humannfolder, "merged", "genefamilies_relab.tsv"),
-        path = os.path.join(humannfolder, "merged", "pathabundance_relab.tsv"),
-        ec = os.path.join(humannfolder, "merged", "ecs_relab.tsv")
+        gf = expand(os.path.join(humannfolder, "main", "{sample}_genefamilies_names.tsv"), sample=samples),
+        path = expand(os.path.join(humannfolder, "relab", "{sample}_pathabundance_relab.tsv"), sample=samples),
+        ec = expand(os.path.join(humannfolder, "main", "{sample}_ecs_names.tsv"), sample=samples),
+        ko = expand(os.path.join(humannfolder, "main", "{sample}_kos_names.tsv"), sample=samples)
     output:
         os.path.join(humannfolder, "humann2_report.html")
     run:

--- a/workflows/kneaddata.snakefile
+++ b/workflows/kneaddata.snakefile
@@ -16,48 +16,47 @@ rule kneaddata:
         rev = os.path.join(input_folder, "{sample}_2.fastq.gz"),
         db = config["databases"]["human_sequences"]
     output:
-        fwd = temp(os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq")),
-        rev = temp(os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq"))
+        fwd = os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq"),
+        rev = os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq"),
+        log = os.path.join(kneadfolder, "{sample}_kneaddata.log")
     run:
         shell("kneaddata --input {{input.fwd}} --input {{input.rev}} --reference-db {{input.db}} --output {} --output-prefix {{wildcards.sample}}_kneaddata".format(kneadfolder))
 
-rule kneaddata_gzip:
-    input:
-        fwd = os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq"),
-        rev = os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq")
-    output:
-        fwd = os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq.gz"),
-        rev = os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq.gz")
-    run:
-         for f in glob.glob(os.path.join(kneadfolder, "{wildcards.sample}*")):
-             shell("gzip -v {}".format(f))
-
 rule kneaddata_counts:
-    input:
-        fwd = dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_1.fastq"), sample = samples)),
-        rev = dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_2.fastq"), sample = samples))
-    output:
-        os.path.join(kneadfolder, "kneaddata_read_counts.txt")
+    input: expand(os.path.join(kneadfolder, "{sample}_kneaddata.log"), sample = samples)
+    output: os.path.join(kneadfolder, "kneaddata_read_counts.txt")
     shell:
         "kneaddata_read_count_table --input {} --output {{output}}".format(kneadfolder)
 
-rule kneaddata_gzip_foward:
-    input: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_1.fastq"), sample = samples))
-    output: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_1.fastq.gz"), sample = samples))
-    run:
-        shell("gzip {input}")
+# rule kneaddata_gzip:
+#     input:
+#         log = os.path.join(kneadfolder, "{sample}_kneaddata.log"),
+#         fwd = os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq"),
+#         rev = os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq")
+#     output:
+#         fwd = os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq.gz"),
+#         rev = os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq.gz")
+#     run:
+#          for f in glob.glob(os.path.join(kneadfolder, "{wildcards.sample}*")):
+#              shell("gzip -v {}".format(f))
 
-rule kneaddata_gzip_reverse:
-    input: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_2.fastq"), sample = samples))
-    output: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_2.fastq.gz"), sample = samples))
-    run:
-        shell("gzip {input}")
+# rule kneaddata_gzip_foward:
+#     input: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_1.fastq"), sample = samples))
+#     output: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_1.fastq.gz"), sample = samples))
+#     run:
+#         shell("gzip {input}")
+#
+# rule kneaddata_gzip_reverse:
+#     input: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_2.fastq"), sample = samples))
+#     output: dynamic(expand(os.path.join(kneadfolder, "{sample}_{{filter_type}}_2.fastq.gz"), sample = samples))
+#     run:
+#         shell("gzip {input}")
 
 rule kneaddata_report:
     input:
         counts = os.path.join(kneadfolder, "kneaddata_read_counts.txt"),
-        fwd = expand(os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq.gz"), sample = samples),
-        rev = expand(os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq.gz"), sample = samples)
+        fwd = expand(os.path.join(kneadfolder, "{sample}_kneaddata_paired_1.fastq"), sample = samples),
+        rev = expand(os.path.join(kneadfolder, "{sample}_kneaddata_paired_2.fastq"), sample = samples)
     output:
         os.path.join(kneadfolder, "kneaddata_report.html")
     run:

--- a/workflows/metaphlan2.snakefile
+++ b/workflows/metaphlan2.snakefile
@@ -30,12 +30,6 @@ rule metaphlan2_bz2:
     run:
         shell("bzip2 {input}")
 
-rule metaphlan2_bz2:
-    input: os.path.join(metaphlanfolder, "main", "{sample}.sam")
-    output: os.path.join(metaphlanfolder, "main", "{sample}.sam.bz2")
-    run:
-        shell("bzip2 {input}")
-
 rule metaphlan2_report:
     input:
         abundance_table = os.path.join(metaphlanfolder, "merged", "merged_abundance_table.tsv"),


### PR DESCRIPTION
supercedes #28 

- Update `humann2` call to use fastq files from `kneaddata` and taxonomic profiles from `metaphlan2`.
- update `cluster_template.yaml` to give 12 hours (rather than 12 minutes) to humann2
- not part of this PR, but also needed to update Diamond on the cluster to make this work consistently