### PR TITLE
Make paths absolute

### DIFF
--- a/setup/directories.smk
+++ b/setup/directories.smk
@@ -1,5 +1,5 @@
-input_folder = config["input_folder"]
-output_folder = config["output_folder"]
+input_folder = os.path.abspath(config["input_folder"])
+output_folder = os.path.abspath(config["output_folder"])
 log_folder = os.path.join(output_folder, "logs")
 
 if not os.path.isdir(output_folder):


### PR DESCRIPTION
Not having absolute paths was causing some problems when using `singularity` on the cluster. I don't understand why, but this fixes it.